### PR TITLE
Update to support multiple nets

### DIFF
--- a/pkg/apis/config/v1alpha4/types.go
+++ b/pkg/apis/config/v1alpha4/types.go
@@ -118,6 +118,15 @@ type Node struct {
 	// binded to a host Port
 	ExtraPortMappings []PortMapping `yaml:"extraPortMappings,omitempty"`
 
+	// Docker networks to attach to. Defaults to the Docker default ("bridge").
+	Networks []string `json:"networks,omitempty"`
+
+	// Loopback IP.
+	Loopback string `json:"loopback,omitempty"`
+
+	// Routes.
+	Routes []string `json:"routes,omitempty"`
+
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// merge patches. The `kind` field must match the target object, and
 	// if `apiVersion` is specified it will only be applied to matching objects.

--- a/pkg/cluster/constants/constants.go
+++ b/pkg/cluster/constants/constants.go
@@ -46,4 +46,7 @@ const (
 	// Please note that `kind` nodes hosting external etcd are not
 	// kubernetes nodes
 	ExternalEtcdNodeRoleValue string = "external-etcd"
+
+	NodeLoopbackKey string = "io.k8s.sigs.kind.loopback"
+	NodeRoutesKey   string = "io.k8s.sigs.kind.routes"
 )

--- a/pkg/cluster/internal/create/actions/loopback/loopback.go
+++ b/pkg/cluster/internal/create/actions/loopback/loopback.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeadminit implements the kubeadm init action
+package loopback
+
+import (
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions"
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+// kubeadmInitAction implements action for executing the kubadm init
+// and a set of default post init operations like e.g. install the
+// CNI network plugin.
+type action struct{}
+
+// NewAction returns a new action for kubeadm init
+func NewAction() actions.Action {
+	return &action{}
+}
+
+// Execute runs the action
+func (a *action) Execute(ctx *actions.ActionContext) error {
+	allNodes, err := ctx.Nodes()
+	if err != nil {
+		return err
+	}
+
+	for _, node := range allNodes {
+		loopAddress, err := node.Loopback()
+		if err != nil {
+			fmt.Printf("Loopback action error: %v\n", err)
+			continue
+		}
+		if loopAddress != "" {
+			fmt.Printf("Add loopback %v for node %v\n", loopAddress, node)
+			cmd := node.Command(
+				"ip",
+				"a",
+				"a",
+				loopAddress+"/32",
+				"dev",
+				"lo",
+			)
+			err := cmd.Run()
+			if err != nil {
+				return errors.Wrap(err, "failed to set loopback address")
+			}
+		}
+
+		routes, err := node.Routes()
+		if err != nil {
+			fmt.Printf("Loopback action error: %v\n", err)
+			continue
+		}
+		for _, route := range strings.Split(routes, ",") {
+			fmt.Printf("Install route: %v\n", route)
+			args := []string{"r", "a"}
+			args = append(args, strings.Split(route, " ")...)
+			cmd := node.Command("ip", args...)
+			err := cmd.Run()
+			if err != nil {
+				return errors.Wrap(err, "failed to install route")
+			}
+		}
+
+	}
+	return nil
+}

--- a/pkg/cluster/internal/create/create.go
+++ b/pkg/cluster/internal/create/create.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadminit"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/kubeadmjoin"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/loadbalancer"
+	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/loopback"
 	"sigs.k8s.io/kind/pkg/cluster/internal/create/actions/waitforready"
 	"sigs.k8s.io/kind/pkg/cluster/internal/kubeconfig"
 )
@@ -109,6 +110,7 @@ func Cluster(logger log.Logger, p providers.Provider, opts *ClusterOptions) erro
 	// TODO(bentheelder): make this controllable from the command line?
 	actionsToRun := []actions.Action{
 		loadbalancer.NewAction(), // setup external loadbalancer
+		loopback.NewAction(),     // add loopback addresses
 		configaction.NewAction(), // setup kubeadm config
 	}
 	if !opts.StopBeforeSettingUpKubernetes {

--- a/pkg/cluster/nodes/types.go
+++ b/pkg/cluster/nodes/types.go
@@ -31,6 +31,7 @@ type Node interface {
 	String() string // see also: fmt.Stringer
 	// Role should return the node's role
 	Role() (string, error) // see also: pkg/cluster/constants
+	Loopback() (string, error)
 	// TODO(bentheelder): should return node addresses more generally
 	// Possibly remove this method in favor of obtaining this detail with
 	// exec or from the provider

--- a/pkg/internal/apis/config/types.go
+++ b/pkg/internal/apis/config/types.go
@@ -98,6 +98,15 @@ type Node struct {
 	// binded to a host Port
 	ExtraPortMappings []PortMapping
 
+	// Docker networks to attach to. Defaults to the Docker default ("bridge").
+	Networks []string
+
+	// Loopback IP.
+	Loopback string
+
+	// Routes
+	Routes []string
+
 	// KubeadmConfigPatches are applied to the generated kubeadm config as
 	// strategic merge patches to `kustomize build` internally
 	// https://github.com/kubernetes/community/blob/a9cf5c8f3380bb52ebe57b1e2dbdec136d8dd484/contributors/devel/sig-api-machinery/strategic-merge-patch.md


### PR DESCRIPTION
Reproducing the work done in these commits, but against the latest kind:

- https://github.com/projectcalico/kind/commit/b8ea23d375f2df6d548fb10c09c5c309008bae8c
- https://github.com/projectcalico/kind/commit/d90a7cecd39c07aca98996ff66902d0b087ce70e
- https://github.com/projectcalico/kind/commit/c156e27d2d59d7b519db025b02492753dc6ba61e
- https://github.com/projectcalico/kind/commit/ce5608028ccfeb1ca645c5a2763065eca559ef6b
- https://github.com/projectcalico/kind/commit/55cfb0a8d2a2ce0985728216e94bbc2527bb669c?branch=55cfb0a8d2a2ce0985728216e94bbc2527bb669c&diff=unified

Originally on this branch: https://github.com/projectcalico/kind/commits/kind-multiple-networks